### PR TITLE
Fixes broken npm coverage command for travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test": "./node_modules/grunt-cli/bin/grunt ci",
-    "coverage": "istanbul cover jasmine-node test/**/*Spec.js --captureExceptions test",
+    "coverage": "istanbul cover ./node_modules/grunt-jasmine-node/node_modules/.bin/jasmine-node test/**/*Spec.js --captureExceptions test",
     "coveralls": "npm run-script coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "engines": {


### PR DESCRIPTION
I broke travis coverage command on the last pull request. This should fix it.

Waiting until the automated travis build runs on this pull request to verify before I merge it.
