### PR TITLE
Updated to work with jasmine-2.0

### DIFF
--- a/lib/pongular-mocks.js
+++ b/lib/pongular-mocks.js
@@ -1,16 +1,32 @@
-/*global require: false, exports: false, global: false, beforeEach: false, afterEach: false */
+/*global require: false, exports: false, global: false, beforeEach: false, afterEach: false, setup: false, teardown: false  */
 
 var pongular = require('./pongular').pongular,
     utils = require('./utils');
 
 if(global.jasmine || global.mocha) {
 
-  var currentSpec = function() {
-    return global.jasmine.getEnv().currentSpec;
-  },
+  var currentSpec = null,
       isSpecRunning = function() {
-        return currentSpec() && currentSpec().queue.running;
+        return !!currentSpec;
       };
+  
+  (beforeEach || setup)(function() {
+    currentSpec = this;
+  });
+  
+  (afterEach || teardown)(function() {
+    var injector = currentSpec.$injector;
+    
+    utils.forEach(currentSpec.$modules, function(module) {
+      if (module && module.$$hashKey) {
+        module.$$hashKey = undefined;
+      }
+    });
+    
+    currentSpec.$injector = null;
+    currentSpec.$modules = null;
+    currentSpec = null;
+  });
 
   /**
      * @ngdoc function
@@ -34,10 +50,10 @@ if(global.jasmine || global.mocha) {
     /////////////////////
     function workFn() {
 
-      if (currentSpec().$injector) {
+      if (currentSpec.$injector) {
         throw new Error('Injector already created, can not register a module!');
       } else {
-        var modules = currentSpec().$modules || (currentSpec().$modules = []);
+        var modules = currentSpec.$modules || (currentSpec.$modules = []);
         utils.forEach(moduleFns, function(module) {
           if (utils.isObject(module) && !utils.isArray(module)) {
             modules.push(function($provide) {
@@ -143,11 +159,11 @@ if(global.jasmine || global.mocha) {
     return isSpecRunning() ? workFn() : workFn;
     /////////////////////
     function workFn() {
-      var modules = currentSpec().$modules || [];
+      var modules = currentSpec.$modules || [];
 
-      var injector = currentSpec().$injector;
+      var injector = currentSpec.$injector;
       if (!injector) {
-        injector = currentSpec().$injector = pongular.injector(modules);
+        injector = currentSpec.$injector = pongular.injector(modules);
       }
       for(var i = 0, ii = blockFns.length; i < ii; i++) {
         try {


### PR DESCRIPTION
Although I haven't updated the project to `Jasmine 2.0`, this change is backwards compatible. I chose not to update the project to `2.0` because it involves updating many of the tests and the `grunt-jasmine-node` project has not "officially" added support for it yet (although it's available via some forks/branches).

Anyway, the tests still all pass on this project and works on the project that I'm using `Jasmine 2.0` on so I think it's good to go.

Just want to run it by you @FungusHumungus incase I'm missing anything.

Once this is merged @FungusHumungus you will have to increment the package version and tag a new release.
