### PR TITLE
fix HashMap so it no longer hashes all functions using their source stri...

### DIFF
--- a/lib/apis.js
+++ b/lib/apis.js
@@ -50,7 +50,7 @@ function hashKey(obj) {
     var objType = typeof obj,
         key;
 
-    if (objType == 'object' && obj !== null) {
+    if (objType == 'function' || (objType == 'object' && obj !== null)) {
         if (typeof (key = obj.$$hashKey) == 'function') {
             // must invoke on object to keep the right this
             key = obj.$$hashKey();

--- a/test/pongular-mocksSpec.js
+++ b/test/pongular-mocksSpec.js
@@ -49,17 +49,35 @@ describe('pongular mocks', function() {
           function testFn() {
 
           }
-          
-          // TODO: test not passing... why?
-          xit('should add hashKey to module function', function() {
+
+          it('should add hashKey to module function', function() {
             module(testFn);
             inject(function () {
               expect(testFn.$$hashKey).toBeDefined();
             });
           });
-          
+
           it('should cleanup hashKey after previous test', function() {
             expect(testFn.$$hashKey).toBeUndefined();
+          });
+        });
+
+        describe('called multiple times', function() {
+          var secondMock = {};
+
+          it('should apply all mocks', function() {
+            module({foo: secondMock});
+            inject(function (service, foo) {
+              expect(service).toEqual(mock);
+              expect(foo).toEqual(secondMock);
+            });
+          });
+
+          it('should override earlier mocks with later ones', function() {
+            module({service: secondMock});
+            inject(function (service) {
+              expect(service).toEqual(secondMock);
+            });
           });
         });
       });


### PR DESCRIPTION
This was causing different function instances created from the same source code
(e.g. as local functions inside the same function) to be hashed the same.

One of the effects was that when using `mocks.module()` and passing it an object
like so:

``` javascript
  mocks.module({myService: 42});
```

worked if it was the first such `mocks.module()` call for a single test. Any later
later such calls (whether passing them same or different object) were simply
ignored by the constructed mocks injector. This is so because all such passed
objects are actually represented as functions in an internal pongular module list
and, since they are all constructed using the same source, they are all hashed
the same so when pongular asks 'do I already have this module loaded?' it thinks
the answer is yes as it can find that same hash in its `HashMap` of already loaded
modules.

Matching workaround has long since been applied in angular sources.
